### PR TITLE
Update media_player.py to add "Game" as on state.

### DIFF
--- a/custom_components/xboxone/media_player.py
+++ b/custom_components/xboxone/media_player.py
@@ -549,7 +549,7 @@ class XboxOneDevice(MediaPlayerDevice):
         if playback_state:
             state = playback_state
         elif self._xboxone.connected or self._xboxone.available:
-            if self._xboxone.active_app_type in ['Application', 'App'] or self._xboxone.active_app == 'Home':
+            if self._xboxone.active_app_type in ['Application', 'App', 'Game'] or self._xboxone.active_app == 'Home':
                 state = STATE_ON
             else:
                 state = STATE_UNKNOWN


### PR DESCRIPTION
Add "Game" as an on state in line 550.  This allows the media card to display as expected when Xbox is being used to play a game.