### PR TITLE
Modify XboxOneDevice to extend MediaPlayerEntity

### DIFF
--- a/custom_components/xboxone/media_player.py
+++ b/custom_components/xboxone/media_player.py
@@ -16,7 +16,7 @@ from urllib.parse import urljoin
 from packaging import version
 
 from homeassistant.components.media_player import (
-    MediaPlayerDevice, PLATFORM_SCHEMA)
+    MediaPlayerEntity, PLATFORM_SCHEMA)
 
 from homeassistant.components.media_player.const import (
     SUPPORT_NEXT_TRACK, SUPPORT_PAUSE, SUPPORT_PREVIOUS_TRACK,
@@ -498,7 +498,7 @@ class XboxOne:
             self._update_volume_controls()
 
 
-class XboxOneDevice(MediaPlayerDevice):
+class XboxOneDevice(MediaPlayerEntity):
     """Representation of an Xbox One device on the network."""
 
     def __init__(self, base_url, liveid, ip, name, auth):


### PR DESCRIPTION
Simple change here to modify XboxOneDevice class to extend MediaPlayerEntity instead of MediaPlayerDevice. No change in functionality, just following upstream class naming changes in 0.109 to avoid receiving the warning in the log.