### PR TITLE
Add GitHub Actions

### DIFF
--- a/.github/workflows/combined.yaml
+++ b/.github/workflows/combined.yaml
@@ -1,0 +1,30 @@
+name: "Custom Component CI"
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        name: Download repo
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v2
+        name: Setup Python
+      - uses: actions/cache@v2
+        name: Cache
+        with:
+          path: |
+            ~/.cache/pip
+          key: custom-component-ci
+      - uses: hacs/integration/action@main
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CATEGORY: integration
+      - uses: KTibow/ha-blueprint@stable
+        name: CI
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I recently announced ha-blueprint:
https://community.home-assistant.io/t/made-a-custom-integration-or-card-ive-created-an-all-in-one-github-action-for-you/235041?u=ktibow
This makes CI use it.